### PR TITLE
Clean up nonconforming class/CSS

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -1,22 +1,20 @@
 @charset "utf-8";
 @namespace epub "http://www.idpf.org/2007/ops";
 
-[epub|type~="z3998:letter"] header,
-.newspaper header{
+header{
 	font-variant: small-caps;
+	margin: 1em;
+	text-align: center;
 }
 
-[epub|type~="z3998:letter"] footer,
-.newspaper footer{
+footer{
 	margin-top: 1em;
 	text-align: right;
 }
 
+#chapter-1 blockquote,
+#chapter-2 blockquote,
 [epub|type~="z3998:signature"]{
-	font-variant: small-caps;
-}
-
-.inscription{
 	font-variant: small-caps;
 }
 

--- a/src/epub/text/chapter-1.xhtml
+++ b/src/epub/text/chapter-1.xhtml
@@ -64,7 +64,7 @@
 			<p>“This’ll be the name and address,” he said, pointing to the envelopes in his hand. “<abbr>Mr.</abbr> Robert Hannaford, Malter’s Private Hotel, Surrey Street, Strand. Several letters, you see, addressed there, and all of recent date. We’ll have to go there⁠—there may be his wife and people of his there. Wonder who he was?⁠—somebody from the provinces, most likely. Well⁠—”</p>
 			<p>He laid down the letters and picked up the watch⁠—a fine gold-cased hunter⁠—and released the back. Within that was an inscription, engraved in delicate lettering. The inspector let out an exclamation.</p>
 			<p>“Ah!” he said. “I half suspected that from his appearance. One of ourselves! Look at this⁠—‘</p>
-			<blockquote class="inscription">
+			<blockquote>
 				<p>Presented to Superintendent Robert Hannaford, on his retirement, by the Magistrates of Sellithwaite.</p>
 			</blockquote>
 			<p>Sellithwaite, eh?⁠—where’s that, now?”</p>

--- a/src/epub/text/chapter-15.xhtml
+++ b/src/epub/text/chapter-15.xhtml
@@ -14,7 +14,7 @@
 			<p>The late afternoon edition of the evening papers were just out when Hetherwick and Matherfield reached Victoria. Matherfield snatched one up; a moment later he thrust it before Hetherwick, pointing to some big black capitals.</p>
 			<p>“Good God!” he exclaimed. “Look at that!”</p>
 			<p>Hetherwick looked, and gasped his astonishment at what he read.</p>
-			<blockquote class="newspaper">
+			<blockquote>
 				<header>
 					<p>Murder of Robert Hannaford.<br/>
 					Five Thousand Pounds Reward.</p>
@@ -27,7 +27,7 @@
 			<p>“How do we know who isn’t concerned in the case?” exclaimed Matherfield. “Somebody evidently is!⁠—somebody who can not only afford to offer five thousand pounds, but isn’t afraid to spend no end in advertising. Look at that⁠—and that⁠—and that,” he went on, turning over his purchases rapidly. “It’s in every paper in London!”</p>
 			<p>“Let’s read it carefully,” said Hetherwick. He spread out one of the newspapers on the waiting-room table and muttered the wording of the advertisement while Matherfield looked over his shoulder. “Mysterious, very!” he concluded. “What’s it mean?”</p>
 			<p>But Matherfield was rereading the advertisement.</p>
-			<blockquote class="newspaper">
+			<blockquote>
 				<p>Whereas Robert Hannaford, formerly Superintendent of Police at Sellithwaite, Yorkshire, died suddenly in an Underground Railway train, near Charing Cross (Embankment) Station about 1:15 <abbr>a.m.</abbr> on March 19th last, and expert medical investigation has proved that he was poisoned, and there is evidence to warrant the belief that the poison was administered by some person or persons with intent to cause his death, this is to give notice that the above-mentioned sum of Five Thousand Pounds will be paid to anyone first giving information which will lead to the arrest and conviction of the person or persons concerned in administering the said poison and that such information should be given to the undersigned, who will pay the said reward in accordance with the above-stated conditions.</p>
 				<footer>
 					<p><span epub:type="z3998:signature">Penteney, Blenkinsop &amp; Penteney,</span><br/>

--- a/src/epub/text/chapter-18.xhtml
+++ b/src/epub/text/chapter-18.xhtml
@@ -69,11 +69,11 @@
 			<p>He presently led Hetherwick into the saloon bar of a tavern, and remarking that he had a taste for ale and bread and cheese at that time of day, provided himself with these matters and retreated to a snug corner, whither Hetherwick followed him with a whisky and soda.</p>
 			<p>“Here’s success to our endeavours, <abbr>Mr.</abbr> Hetherwick!” said Matherfield, lifting his tankard. “I’m now firmly under the impression that we’re adding link after link to the chain! But let’s see what we’ve got here in this crabbed writing.”</p>
 			<p>He laid the slips of paper on the table at which they sat; both bent over them. There were not many words on either, but to Hetherwick they were significant enough in their plain straightforwardness.</p>
-			<blockquote epub:type="z3998:letter">
+			<blockquote>
 				<p>Charles Ambrose, <abbr epub:type="z3998:name-title">M.B.</abbr> (Oxon). Medical Officer of Health, Crayport, Lancs, 1903⁠–⁠4; in practice Whiteburn, Lancs, 1904⁠–⁠9; police surgeon, Sellithwaite, <abbr epub:type="z3998:place">WR</abbr>, Yorks, 1909⁠–⁠12; in practice Brondesbury, London, 1912⁠–⁠18. Struck off Register by General Medical Council for unprofessional conduct, 1918.</p>
 			</blockquote>
 			<p>“So much for him!” muttered Matherfield, his cheek bulging with bread and cheese. “I thought it would turn out to be something of that sort! Now t’other!”</p>
-			<blockquote epub:type="z3998:letter">
+			<blockquote>
 				<p>Cyprian Baseverie, <abbr epub:type="z3998:name-title">L.R.C.P.</abbr>, <abbr class="eoc" epub:type="z3998:name-title">L.R.C.S.</abbr> In practice Birmingham, 1897⁠–⁠1902; at Wyborough, Northants, 1902⁠–⁠11; at Dalston, <abbr epub:type="z3998:place">N</abbr>, 1911⁠–⁠17, Convicted of fraud at Central Criminal Court, 1917, and struck off Register by General Medical Council, 1918.</p>
 			</blockquote>
 			<p>“Ho-ho!” exclaimed Matherfield. “Been in the dock already, has he? Well, well, <abbr>Mr.</abbr> Hetherwick, we continue to learn, sir! We know still more. Baseverie’s a convicted criminal. Both have been struck off the register. Ambrose was certainly at Sellithwaite⁠—and he’d be there, according to these dates, at the time of the Whittingham affair. A promising pair⁠—for our purpose! What do you think?”</p>

--- a/src/epub/text/chapter-2.xhtml
+++ b/src/epub/text/chapter-2.xhtml
@@ -74,7 +74,7 @@
 			<p>“Well, this,” she answered. “My grandfather, who, as I dare say you know by this time, was for a good many years Superintendent of Police at Sellithwaite, had a habit of cutting things out of newspapers⁠—paragraphs, accounts of criminal trials, and so on. He had several boxes full of such cuttings. When we were coming to town the other day I saw him cut a photograph out of some illustrated paper he was reading in the train, and put it away in his pocketbook⁠—in a pocketbook, I ought to say, for he had two or three pocketbooks. This morning I was looking through various things which he had left lying about on his dressing-table upstairs, and in one of his pocketbooks I found the photograph which he cut out in the train. That must be the one you mention⁠—it’s of a very handsome, distinguished-looking woman.”</p>
 			<p>“If I may see it⁠—” suggested Hetherwick.</p>
 			<p>Within a couple of minutes he had the cutting in his hand⁠—a scrap of paper, neatly snipped out of its surrounding letterpress, which was a print of a photograph of a woman of apparently thirty-five to forty years of age, evidently of high position, and certainly, as Rhona Hannaford had remarked, of handsome and distinguished features. But it was not at the photograph that Hetherwick gazed with eyes into which surmise and speculation were beginning to steal; after a mere glance at it, his attention fixed itself on some pencilled words on the margin at its sides:</p>
-			<blockquote class="inscription">
+			<blockquote>
 				<p>Through my hands ten years ago!</p>
 			</blockquote>
 			<p>“Is that your grandfather’s writing?” he inquired suddenly.</p>

--- a/src/epub/text/chapter-7.xhtml
+++ b/src/epub/text/chapter-7.xhtml
@@ -39,7 +39,7 @@
 			<p>“Doing the benevolent business, eh?”</p>
 			<p>“So it appears. Easy game, too, when you’ve got a couple of millions behind you. Useful, though.”</p>
 			<p>Boxley went away soon after that, and Hetherwick, wondering about what he had learned, and now infinitely inquisitive about the identity of Lady Riversreade with <abbr>Mrs.</abbr> Whittingham, went into the smoking-room, and more from habit than because he really wanted to see it, picked up a copy of <i epub:type="se:name.publication.newspaper">The Times</i>. Almost the first thing on which his glance lighted was the name that was just then in his thoughts⁠—there it was, in capitals, at the head of an advertisement:</p>
-			<blockquote epub:type="z3998:letter">
+			<blockquote>
 				<header>
 					<p>Lady Riversreade’s Home For Wounded Officers, Surrey.⁠—</p>
 				</header>


### PR DESCRIPTION
Continuing my crusade against the `newspaper` class...

```
wcheng@pop-os:~/git/j-s-fletcher_the-charing-cross-mystery$ se compare-versions .
Difference in chapter-7.xhtml
```

This difference is expected since I added the 1em margin for headers.

I removed the `inscription` class while I was here--I guess you could sort of argue it was a class but those were the only blockquotes in those chapters so it was really easy to write a normal selector for them.

I also removed the letter semantic from some of the blockquotes since they aren't really letters in context.